### PR TITLE
import-tag parsing using SimpleXML

### DIFF
--- a/content/content.debug.php
+++ b/content/content.debug.php
@@ -182,13 +182,15 @@
 		protected function __findUtilitiesInXSL($xsl) {
 			if ($xsl == '') return;
 
-			$utilities = null;
+			$utilities = array();
+			
+			$xsl = new SimpleXMLElement($xsl);
+			
+			$matches = $xsl->xpath("*[local-name()='import' or local-name()='include']");
 
-			// remove comments in XSL to prevent infinite recursion if an XSLT documents an include/import of itself!
-			$xsl = preg_replace('/<!--(.|\s)*?-->/', '', $xsl);
-
-			if (preg_match_all('/<[^:]+:(import|include)\s*href="([^"]*)/i', $xsl, $matches)) {
-				$utilities = $matches[2];
+			foreach($matches AS $match) {
+				$attributes = $match->attributes();
+				$utilities[] = $attributes["href"];
 			}
 
 			if (!is_array($this->_full_utility_list)) {


### PR DESCRIPTION
This commit fixes [issue 532 - Connection interrupted on ?debug](http://symphony-cms.com/discuss/issues/view/532/) by replacing the regex-based import/include tag matchig with proper, XML-aware code.

`local-name()` is necessary to ignore the namespace (some people prefer a shorter, single-character namespace instead of `xsl:`).
