### PR TITLE
Check if utility file exists

### DIFF
--- a/content/content.debug.php
+++ b/content/content.debug.php
@@ -196,7 +196,7 @@
 
 			foreach($matches AS $match) {
 				$attributes = $match->attributes();
-				if($attributes["href"] != basename($filename))
+				if($attributes["href"] != basename($filename) && file_exists(realpath(dirname($filename) . "/" . $attributes["href"])))
 					$utilities[] = realpath(dirname($filename) . "/" . $attributes["href"]);
 			}
 


### PR DESCRIPTION
This change introduces a check for any found utilities file before adding it to the list. This fixes an issue with the URL `efm://functions` added by the EXSLT/PHP functions manager extension.
