### PR TITLE
Performance improvement on tabs replacement

### DIFF
--- a/lib/bitter/formats/symphony.php
+++ b/lib/bitter/formats/symphony.php
@@ -19,9 +19,19 @@
 		}
 		
 		protected function processTabs() {
-			while (strstr($this->output, "\t")) {
-				$this->output = preg_replace_callback('%^([^\t]*)(\t+)%', array($this, 'processTabsLine'), $this->output);
+			// first split the output into manageable chunks
+			$lines = explode(PHP_EOL, $this->output);
+			$linesCount = count($lines);
+			// fix lines one by one
+			for ($x = 0; $x < $linesCount; $x++) {
+				// while there are still tabs
+				while (strpos($lines[$x], "\t") !== FALSE) {
+					// replace tabs for spaces
+					$lines[$x] = preg_replace_callback('%^([^\t]*)([\t]+)%', array($this, 'processTabsLine'), $lines[$x]);
+				}
 			}
+			// concat the final output
+			$this->output = implode(PHP_EOL, $lines);
 		}
 		
 		protected function processTabsLine($matches) {


### PR DESCRIPTION
It processes the regex line by line instead of for the hole output, which drastically reduce the memory consumption.

I had a page with an 8000 line xml that refuses to render under 30 seconds. With this fix, it now renders properly in 7 secs.

Using `strstr` in a while loop is evil too. Using `strpos` is way better (as stated in the php docs).
